### PR TITLE
Set a non-zero exit code when compilation fails

### DIFF
--- a/index.js
+++ b/index.js
@@ -238,6 +238,10 @@ function renderSheet(filename = null, stdin = null) {
         } else {
             process.stderr.write(e.formatted);
         }
+
+        if (!program.watch && (process.exitCode == null || process.exitCode === 0)) {
+            process.exitCode = 1;
+        }
     }
 
 }


### PR DESCRIPTION
Currently, sheetloaf exits with a zero exit code (`process.exitCode`) even when there is a Sass or PostCSS error. When sheetloaf is used as part of an automated build process (which I do), the build will not fail like it should if there is an error, potentially leading to a broken or missing stylesheet being deployed into production.

This PR sets a non-zero exit code on compilation failure (unless sheetloaf is in watch mode).